### PR TITLE
Trim whitespace for date input field

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -58,7 +58,7 @@ var DateInput = React.createClass({
 
   handleChangeDate (value) {
     if (this.props.onChangeDate) {
-      var date = moment(value, this.props.dateFormat, this.props.locale || moment.locale(), true)
+      var date = moment(value.trim(), this.props.dateFormat, this.props.locale || moment.locale(), true)
       if (date.isValid() && !isDayDisabled(date, this.props)) {
         this.props.onChangeDate(date)
       } else if (value === '') {


### PR DESCRIPTION
When pasting in a date it is possible to have extra whitespace. The whitespace prevent the datepicker from recognizing a valid date.